### PR TITLE
fix: Leaky sdk functions

### DIFF
--- a/internal/provider/assemblyai.go
+++ b/internal/provider/assemblyai.go
@@ -10,7 +10,7 @@ import (
 )
 
 type AssemblyAIProvider struct {
-	*assemblyai.Client
+	client *assemblyai.Client
 }
 
 func NewAssemblyAIProvider() *AssemblyAIProvider {
@@ -26,7 +26,7 @@ func (p *AssemblyAIProvider) Transcribe(ctx context.Context, file string, cfg co
 	}
 	defer f.Close()
 
-	transcript, err := p.Transcripts.TranscribeFromReader(ctx, f, &assemblyai.TranscriptOptionalParams{
+	transcript, err := p.client.Transcripts.TranscribeFromReader(ctx, f, &assemblyai.TranscriptOptionalParams{
 		LanguageCode: assemblyai.TranscriptLanguageCode(cfg.Language),
 		FormatText:   assemblyai.Bool(true),
 		SpeechModel:  assemblyai.SpeechModel(cfg.Model),
@@ -40,9 +40,4 @@ func (p *AssemblyAIProvider) Transcribe(ctx context.Context, file string, cfg co
 		text = *transcript.Text
 	}
 	return &Result{Text: text, Raw: transcript}, nil
-}
-
-// Unused - satisfies interface, implement if needed
-func (p *AssemblyAIProvider) Translate(ctx context.Context, file string, cfg config.Config) (*Result, error) {
-	return nil, fmt.Errorf("translation not supported for AssemblyAI")
 }

--- a/internal/provider/deepgram.go
+++ b/internal/provider/deepgram.go
@@ -14,7 +14,7 @@ import (
 )
 
 type DeepgramProvider struct {
-	*api.Client
+	client *api.Client
 }
 
 var deepgramInitOnce sync.Once
@@ -30,7 +30,7 @@ func NewDeepgramProvider() *DeepgramProvider {
 }
 
 func (p *DeepgramProvider) Transcribe(ctx context.Context, file string, cfg config.Config) (*Result, error) {
-	resp, err := p.FromFile(ctx, file, &interfacesv1.PreRecordedTranscriptionOptions{
+	resp, err := p.client.FromFile(ctx, file, &interfacesv1.PreRecordedTranscriptionOptions{
 		Model:       cfg.Model,
 		Language:    cfg.Language,
 		SmartFormat: true,
@@ -47,9 +47,4 @@ func (p *DeepgramProvider) Transcribe(ctx context.Context, file string, cfg conf
 
 	text := strings.TrimSpace(resp.Results.Channels[0].Alternatives[0].Transcript)
 	return &Result{Text: text, Raw: resp}, nil
-}
-
-// Translate is not supported for Deepgram.
-func (p *DeepgramProvider) Translate(ctx context.Context, file string, cfg config.Config) (*Result, error) {
-	return nil, fmt.Errorf("translation not supported for Deepgram")
 }

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -10,7 +10,7 @@ import (
 )
 
 type OpenAIProvider struct {
-	*openai.Client
+	client *openai.Client
 }
 
 func NewOpenAIProvider() *OpenAIProvider {
@@ -18,7 +18,7 @@ func NewOpenAIProvider() *OpenAIProvider {
 }
 
 func (p *OpenAIProvider) Transcribe(ctx context.Context, file string, cfg config.Config) (*Result, error) {
-	resp, err := p.CreateTranscription(ctx, openai.AudioRequest{
+	resp, err := p.client.CreateTranscription(ctx, openai.AudioRequest{
 		Model:    cfg.Model,
 		FilePath: file,
 		Language: cfg.Language,
@@ -31,7 +31,7 @@ func (p *OpenAIProvider) Transcribe(ctx context.Context, file string, cfg config
 }
 
 func (p *OpenAIProvider) Translate(ctx context.Context, file string, cfg config.Config) (*Result, error) {
-	resp, err := p.CreateTranslation(ctx, openai.AudioRequest{
+	resp, err := p.client.CreateTranslation(ctx, openai.AudioRequest{
 		FilePath: file,
 		Model:    cfg.Model,
 		Language: cfg.Language,


### PR DESCRIPTION
- Exposing the sdk type to an unexported field blocks access to SDKs function